### PR TITLE
Preserve attributes of text nodes

### DIFF
--- a/src/quakeml/XmlUtil.js
+++ b/src/quakeml/XmlUtil.js
@@ -55,10 +55,10 @@ var XmlUtil = {
     }
 
     // clean up '#text' nodes
-    if (children.length === 1 && obj['#text']) {
+    if (children.length === 1 &&
+        obj['#text'] &&
+        Object.keys(obj).length === 1) {
       return obj['#text'];
-    } else if (obj['#text']) {
-      delete obj['#text'];
     }
 
     return obj;

--- a/test/spec/XmlUtilTest.js
+++ b/test/spec/XmlUtilTest.js
@@ -28,6 +28,17 @@ describe('XmlUtil unit tests', function () {
       expect(json.el.child1[1]).to.equal('value2');
     });
 
+    it('handles elements with attributes _and_ content', function () {
+      var xmlString,
+          json;
+
+      xmlString = '<el>' +
+          '<child1 attr1="value1">content</child1>' +
+          '</el>';
+      json = XmlUtil.xmlToJson(xmlString);
+      expect(json.el.child1.attr1).to.equal('value1');
+      expect(json.el.child1['#text']).to.equal('content');
+    });
   });
 
 });


### PR DESCRIPTION
This fixes an issue with updated quakeml waveformID elements that include a resource reference as element content, in addition to the sncl attributes, by preserving any non '#text' attributes and keeping element content in the '#text' attribute where it is by default.

I haven't seen any side effects to this yet, but anything using XmlToJson to extract element content (for elements that also had attributes) may need to check whether the value is a string (as it currently is) or an object (as it will be) and access the value via object['#text']. 